### PR TITLE
--cache-timeを指定すると落ちていたので修正しました

### DIFF
--- a/lib/google-ime-skk/cli.rb
+++ b/lib/google-ime-skk/cli.rb
@@ -42,7 +42,7 @@ module GoogleImeSkk::CLI
           opts.proxy = URI.parse(proxy)
         end
         on('-c', '--cache-time 1h', 'Cache keep time') do |ct|
-          opts.cache_time = time_parse(ct)
+          opts.cache_time = GoogleImeSkk::CLI.time_parse(ct)
         end
 
         parse!(ARGV)


### PR DESCRIPTION
度々すみません、u1tnkです。

今度は表題通り--cache-timeを指定するとtime_parseメソッドがundefinedになってましたので呼べていなかっただけのようです。

rubyのバージョン依存で挙動が異なるのかもしれませんが、1.9.2,1.8.7で同じ動作でした。

宜しくお願い致します。
